### PR TITLE
change link behavior to open resource in a new tab

### DIFF
--- a/src/components/pages/main-page/components/resource-card/ResourceCard.tsx
+++ b/src/components/pages/main-page/components/resource-card/ResourceCard.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import Link from 'next/link';
+import React from 'react';
 
 import styles from './ResourceCard.module.scss';
 
@@ -15,7 +15,7 @@ const ResourceCard: React.FC<CardProps> = ({
   href,
 }) => {
   return (
-    <Link href={href}>
+    <Link href={href} target='_blank' >
       <div className={styles['card']}>
         <div className={styles['card-content']}>
           <img src={image} />


### PR DESCRIPTION
This commit updates the link functionality to open the resource in a new tab. By modifying the link attributes, users will now have a better browsing experience as they can easily navigate back to the original page while keeping the resource accessible in a separate tab. This change enhances user convenience and improves overall usability.




