### PR TITLE
bugfix/button-opposite-to-the-Captain

### DIFF
--- a/src/components/pages/account-page/components/group-tab/components/table/student-table/components/EditingColumn.tsx
+++ b/src/components/pages/account-page/components/group-tab/components/table/student-table/components/EditingColumn.tsx
@@ -82,7 +82,10 @@ const EditingColumn: FC<EditingColumnProps> = ({ student, refetch }) => {
       <ArrowUpCircleIcon />
     );
 
-  if (user.group?.role === UserGroupRole.CAPTAIN) {
+  if (
+    user.group?.role === UserGroupRole.CAPTAIN &&
+    student.role !== UserGroupRole.CAPTAIN
+  ) {
     return (
       <>
         <Popup
@@ -90,12 +93,12 @@ const EditingColumn: FC<EditingColumnProps> = ({ student, refetch }) => {
           title={
             student.role === UserGroupRole.MODERATOR
               ? 'Зробити студентом'
-              : 'Зробити зам старостою'
+              : 'Зробити заст. старости'
           }
           text={`Ви дійсно бажаєте зробити користувача ${student.fullName} ${
             student.role === UserGroupRole.MODERATOR
               ? 'студентом'
-              : 'зам старостою'
+              : 'заст. старости'
           }?`}
           onClose={() => setChangePopupOpen(false)}
           firstButton={


### PR DESCRIPTION
removed "Заст. старости" button opposite the group Captain, removed delete button opposite the group Captain, replaced "зам старостою" with "заст. старости" in the Popup