### PR TITLE
bugfix: saving and displaying symbols in email (#758)

### DIFF
--- a/src/components/pages/email-confirmation-page/EmailConfirmationPage.tsx
+++ b/src/components/pages/email-confirmation-page/EmailConfirmationPage.tsx
@@ -28,7 +28,7 @@ const EmailConfirmationPage: FC<EmailConfirmationPageProps> = ({
 }) => {
   const { displayError } = useToastError();
   const router = useRouter();
-  const email = String(router.query.email).toLowerCase();
+  const email = decodeURIComponent(String(router.query.email)).toLowerCase();
   const emailText =
     apiMethodName === 'forgotPassword'
       ? `Ми надіслали листа для зміни пароля на адресу ${email}`

--- a/src/components/pages/password-recovery/forgot-password-page/components/forgot-password-form/ForgotPasswordForm.tsx
+++ b/src/components/pages/password-recovery/forgot-password-page/components/forgot-password-form/ForgotPasswordForm.tsx
@@ -20,7 +20,11 @@ const ForgotPasswordForm: FC = () => {
     try {
       const email = values.email.toLowerCase();
       await AuthAPI.forgotPassword({ email });
-      await router.push(`/password-recovery/email-verification?email=${email}`);
+      await router.push(
+        `/password-recovery/email-verification?email=${encodeURIComponent(
+          email,
+        )}`,
+      );
     } catch (error) {
       displayError(error);
     }

--- a/src/components/pages/register/register-page/components/register-form/RegisterForm.tsx
+++ b/src/components/pages/register/register-page/components/register-form/RegisterForm.tsx
@@ -44,7 +44,9 @@ const RegisterForm: FC<GetAllResponse> = ({ groups }) => {
         } else {
           await AuthService.register(transformData(data));
           StorageUtil.deleteTelegramInfo();
-          await router.push(`/register/email-verification?email=${email}`);
+          await router.push(
+            `/register/email-verification?email=${encodeURIComponent(email)}`,
+          );
         }
       } catch (error) {
         displayError(error);


### PR DESCRIPTION
Added encoding and decoding of email during routing so it saves special symbols in ASCII format to prevent their missing while displayed on page. Double-check the code (might break the email sending system)